### PR TITLE
allow wrapped hooks to pass error through to node-orm

### DIFF
--- a/lib/orm-timestamps.js
+++ b/lib/orm-timestamps.js
@@ -23,14 +23,18 @@ function Plugin(db, opts) {
 		if(typeof hooks[hookName] == 'function') {
 			var oldHook = hooks[hookName];
 			hooks[hookName] = function(next) {
-				var cont = function() {
-					postLogic.call(this);
-					next();
+				var cont = function(err) {
+					if(err){
+						next(err);
+					}else{
+						postLogic.call(this);
+						next();
+					}
 				}
 
 				var that = this;
-				oldHook.call(this, function() {
-					cont.call(that);
+				oldHook.call(this, function(err) {
+					cont.call(that, err);
 				});
 
 				if(oldHook.length == 0) cont.call(this);


### PR DESCRIPTION
`before*` hooks in node-orm support the ability to pass an error to their next block to halt the operation.

I've added the ability for the wrapped hook to pass an error parameter, which will in turn be passed to node-orm.
